### PR TITLE
Add unit tests for token service operations

### DIFF
--- a/internal/core/usecase/token/create_token_test.go
+++ b/internal/core/usecase/token/create_token_test.go
@@ -1,1 +1,105 @@
 package token_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lechitz/AionApi/internal/core/domain"
+	"github.com/lechitz/AionApi/internal/core/usecase/token/constants"
+	"github.com/lechitz/AionApi/tests/setup"
+	"github.com/lechitz/AionApi/tests/testdata"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+// TestCreateToken_NoExistingToken_Success verifies that a token is created and
+// saved when none exists for the given user.
+func TestCreateToken_NoExistingToken_Success(t *testing.T) {
+	suite := setup.TokenServiceTest(t, constants.SecretKey)
+	defer suite.Ctrl.Finish()
+
+	input := domain.TokenDomain{UserID: testdata.TestPerfectToken.UserID}
+
+	suite.TokenStore.EXPECT().
+		Get(suite.Ctx, input).
+		Return("", errors.New("not found"))
+
+	suite.TokenStore.EXPECT().
+		Save(suite.Ctx, gomock.AssignableToTypeOf(domain.TokenDomain{UserID: input.UserID})).
+		Return(nil)
+
+	token, err := suite.TokenService.CreateToken(suite.Ctx, input)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+}
+
+// TestCreateToken_WithExistingToken_Success ensures that any existing token is
+// removed before creating a new one.
+func TestCreateToken_WithExistingToken_Success(t *testing.T) {
+	suite := setup.TokenServiceTest(t, constants.SecretKey)
+	defer suite.Ctrl.Finish()
+
+	input := domain.TokenDomain{UserID: testdata.TestPerfectToken.UserID}
+
+	suite.TokenStore.EXPECT().
+		Get(suite.Ctx, input).
+		Return("oldtoken", nil)
+
+	suite.TokenStore.EXPECT().
+		Delete(suite.Ctx, input).
+		Return(nil)
+
+	suite.TokenStore.EXPECT().
+		Save(suite.Ctx, gomock.AssignableToTypeOf(domain.TokenDomain{UserID: input.UserID})).
+		Return(nil)
+
+	token, err := suite.TokenService.CreateToken(suite.Ctx, input)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+}
+
+// TestCreateToken_DeleteFails checks that an error is returned when removing an
+// existing token fails.
+func TestCreateToken_DeleteFails(t *testing.T) {
+	suite := setup.TokenServiceTest(t, constants.SecretKey)
+	defer suite.Ctrl.Finish()
+
+	input := domain.TokenDomain{UserID: testdata.TestPerfectToken.UserID}
+
+	suite.TokenStore.EXPECT().
+		Get(suite.Ctx, input).
+		Return("oldtoken", nil)
+
+	suite.TokenStore.EXPECT().
+		Delete(suite.Ctx, input).
+		Return(errors.New("delete err"))
+
+	token, err := suite.TokenService.CreateToken(suite.Ctx, input)
+
+	require.Error(t, err)
+	require.Empty(t, token)
+}
+
+// TestCreateToken_SaveFails checks that an error is returned when saving the new
+// token fails.
+func TestCreateToken_SaveFails(t *testing.T) {
+	suite := setup.TokenServiceTest(t, constants.SecretKey)
+	defer suite.Ctrl.Finish()
+
+	input := domain.TokenDomain{UserID: testdata.TestPerfectToken.UserID}
+
+	suite.TokenStore.EXPECT().
+		Get(suite.Ctx, input).
+		Return("", errors.New("not found"))
+
+	suite.TokenStore.EXPECT().
+		Save(suite.Ctx, gomock.AssignableToTypeOf(domain.TokenDomain{UserID: input.UserID})).
+		Return(errors.New("save err"))
+
+	token, err := suite.TokenService.CreateToken(suite.Ctx, input)
+
+	require.Error(t, err)
+	require.Empty(t, token)
+}

--- a/internal/core/usecase/token/delete_token_test.go
+++ b/internal/core/usecase/token/delete_token_test.go
@@ -1,1 +1,43 @@
 package token_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lechitz/AionApi/internal/core/usecase/token/constants"
+	"github.com/lechitz/AionApi/tests/setup"
+	"github.com/lechitz/AionApi/tests/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDeleteToken_Success verifies that deleting a token succeeds.
+func TestDeleteToken_Success(t *testing.T) {
+	suite := setup.TokenServiceTest(t, constants.SecretKey)
+	defer suite.Ctrl.Finish()
+
+	input := testdata.TestPerfectToken
+
+	suite.TokenStore.EXPECT().
+		Delete(suite.Ctx, input).
+		Return(nil)
+
+	err := suite.TokenService.Delete(suite.Ctx, input)
+
+	require.NoError(t, err)
+}
+
+// TestDeleteToken_Error ensures repository delete errors are returned.
+func TestDeleteToken_Error(t *testing.T) {
+	suite := setup.TokenServiceTest(t, constants.SecretKey)
+	defer suite.Ctrl.Finish()
+
+	input := testdata.TestPerfectToken
+
+	suite.TokenStore.EXPECT().
+		Delete(suite.Ctx, input).
+		Return(errors.New("delete failed"))
+
+	err := suite.TokenService.Delete(suite.Ctx, input)
+
+	require.Error(t, err)
+}

--- a/internal/core/usecase/token/save_token_test.go
+++ b/internal/core/usecase/token/save_token_test.go
@@ -1,1 +1,43 @@
 package token_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/lechitz/AionApi/internal/core/usecase/token/constants"
+	"github.com/lechitz/AionApi/tests/setup"
+	"github.com/lechitz/AionApi/tests/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSaveToken_Success validates that a token is stored successfully.
+func TestSaveToken_Success(t *testing.T) {
+	suite := setup.TokenServiceTest(t, constants.SecretKey)
+	defer suite.Ctrl.Finish()
+
+	input := testdata.TestPerfectToken
+
+	suite.TokenStore.EXPECT().
+		Save(suite.Ctx, input).
+		Return(nil)
+
+	err := suite.TokenService.Save(suite.Ctx, input)
+
+	require.NoError(t, err)
+}
+
+// TestSaveToken_Error ensures that repository errors are propagated.
+func TestSaveToken_Error(t *testing.T) {
+	suite := setup.TokenServiceTest(t, constants.SecretKey)
+	defer suite.Ctrl.Finish()
+
+	input := testdata.TestPerfectToken
+
+	suite.TokenStore.EXPECT().
+		Save(suite.Ctx, input).
+		Return(errors.New("save failed"))
+
+	err := suite.TokenService.Save(suite.Ctx, input)
+
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- implement comprehensive tests for token service's CreateToken, Save and Delete
- cover success and error scenarios using the existing test setup

## Testing
- `go test ./...` *(fails: module downloads blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6852f29e5588832c91fea0cc8010f7eb